### PR TITLE
fix: cache loaded SQL queries and release connections via DataSourceUtils

### DIFF
--- a/wirej/src/main/java/io/github/gergilcan/wirej/database/ConnectionHandler.java
+++ b/wirej/src/main/java/io/github/gergilcan/wirej/database/ConnectionHandler.java
@@ -20,4 +20,16 @@ public class ConnectionHandler {
 		log.debug("Connection obtained: {}", connection);
 		return connection;
 	}
+
+	/**
+	 * Releases a connection obtained from {@link #getConnection()}. Uses
+	 * {@link DataSourceUtils#releaseConnection} so that a connection bound to an
+	 * active Spring-managed transaction is left open for the transaction, and a
+	 * standalone connection is returned to the pool. Calling
+	 * {@code connection.close()} directly would close a transaction's connection
+	 * prematurely.
+	 */
+	public void releaseConnection(Connection connection) {
+		DataSourceUtils.releaseConnection(connection, dataSource);
+	}
 }

--- a/wirej/src/main/java/io/github/gergilcan/wirej/database/DatabaseStatement.java
+++ b/wirej/src/main/java/io/github/gergilcan/wirej/database/DatabaseStatement.java
@@ -9,6 +9,8 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -38,6 +40,14 @@ public class DatabaseStatement<T> {
   private PostgresEntityMapper entityMapper = new PostgresEntityMapper();
   private long startTime;
   private String fileName;
+  private ConnectionHandler connectionHandler;
+
+  // Query text is identical for every call, so read each .sql file from the
+  // classpath once and reuse it. Avoids re-reading (and re-allocating) on every
+  // query, and removes a source of flaky "File not found" errors when the
+  // classpath resource is momentarily unavailable (e.g. target/classes being
+  // rewritten by a concurrent build).
+  private static final Map<String, String> QUERY_CACHE = new ConcurrentHashMap<>();
 
   public DatabaseStatement(String fileName, ConnectionHandler connectionHandler) throws IOException, SQLException {
     this(fileName, null, connectionHandler);
@@ -47,17 +57,28 @@ public class DatabaseStatement<T> {
       throws IOException, SQLException {
     this.fileName = fileName;
     this.entityClass = entityClass;
+    this.connectionHandler = connectionHandler;
 
-    try (var file = getClass().getResourceAsStream(fileName)) {
-      startTime = System.currentTimeMillis();
+    startTime = System.currentTimeMillis();
+    originalQuery = loadQuery(fileName);
+    connection = connectionHandler.getConnection();
+    log.debug("Statement and connection created: executed in {}ms", System.currentTimeMillis() - startTime);
+  }
 
+  // Reads the SQL for fileName from the classpath, caching it after the first
+  // successful read so subsequent calls never touch the filesystem.
+  private static String loadQuery(String fileName) throws IOException {
+    var cached = QUERY_CACHE.get(fileName);
+    if (cached != null) {
+      return cached;
+    }
+    try (var file = DatabaseStatement.class.getResourceAsStream(fileName)) {
       if (file == null) {
         throw new IOException("File not found: " + fileName);
       }
-
-      originalQuery = new String(file.readAllBytes());
-      connection = connectionHandler.getConnection();
-      log.debug("Statement and connection created: executed in {}ms", System.currentTimeMillis() - startTime);
+      var query = new String(file.readAllBytes());
+      QUERY_CACHE.put(fileName, query);
+      return query;
     }
   }
 
@@ -175,7 +196,7 @@ public class DatabaseStatement<T> {
   }
 
   private void close() throws SQLException {
-    connection.close();
+    connectionHandler.releaseConnection(connection);
     log.debug("Query: " + fileName + " executed in " + (System.currentTimeMillis() - startTime) + "ms");
   }
 
@@ -184,8 +205,8 @@ public class DatabaseStatement<T> {
       batchStatement.close();
       batchStatement = null;
     }
-    if (connection != null && !connection.isClosed()) {
-      connection.close();
+    if (connection != null) {
+      connectionHandler.releaseConnection(connection);
       connection = null;
     }
   }


### PR DESCRIPTION
## Summary

Two fixes in `DatabaseStatement` / `ConnectionHandler`.

### 1. Cache loaded SQL queries (fixes flaky `File not found`)

`DatabaseStatement` re-read each `.sql` file from the classpath on **every**
query via `getClass().getResourceAsStream(fileName)`. Because the resource is
read on every call, there is a wide window to catch it mid-rewrite: when
`target/classes` is briefly rewritten by a concurrent build (e.g. an IDE/JDT
auto-build, or an overlapping `mvn`), `getResourceAsStream` returns `null` and
the call fails with `IOException: File not found: /queries/...`. This surfaced
as rare, bursty integration-test failures (e.g. on the `create the roles`
background step).

The query text is identical for every call, so it is now read **once per file**
into a static `ConcurrentHashMap` and reused. This removes the flake and also
avoids re-reading + re-allocating the SQL on every query.

### 2. Release connections via `DataSourceUtils.releaseConnection`

The connection is obtained with `DataSourceUtils.getConnection(dataSource)` but
was released with `connection.close()`. Under an active Spring-managed
transaction that closes the transaction's connection prematurely.
`ConnectionHandler.releaseConnection(...)` now delegates to
`DataSourceUtils.releaseConnection(connection, dataSource)`, which leaves a
transaction-bound connection to the transaction and returns a standalone
connection to the pool.

## Notes

- `mvn -DskipTests compile` passes.
- No public API or behavior change for callers — resource lookups are identical,
  just cached; connection release is the Spring-recommended counterpart to
  `DataSourceUtils.getConnection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
